### PR TITLE
022/bugfix schema strict mode

### DIFF
--- a/src/domain/entity/pokemon.ts
+++ b/src/domain/entity/pokemon.ts
@@ -14,7 +14,7 @@ export class Pokemon {
         maximum: string
     };
     fleeRate: number;
-    previousEvolutions?: {
+    "Previous evolution(s)"?: {
         id: number,
         name: string
     }[]
@@ -41,5 +41,14 @@ export class Pokemon {
         }[]
     }
     favorite: boolean;
+
+    "Pokémon Class"?: string
+    "LEGENDARY"?: string
+    "MYTHIC"?: string
+    "Common Capture Area"?: string
+    "Asia"?: string
+    "North America"?: string
+    "Western Europe"?: string
+    "Australia, New Zealand"?: string
 }
 

--- a/src/infrastructure/mongoDB/schemas/nestSchemas.schema.ts
+++ b/src/infrastructure/mongoDB/schemas/nestSchemas.schema.ts
@@ -1,7 +1,7 @@
 import { Prop, Schema, SchemaFactory } from '@nestjs/mongoose';
 import { Document } from 'mongoose';
 
-@Schema()
+@Schema({ strict: "throw" })
 export class HeightWeight {
     @Prop()
     _id: false;
@@ -42,7 +42,7 @@ export class Evolution {
 export const EvolutionSchema = SchemaFactory.createForClass(Evolution);
 
 
-@Schema()
+@Schema({ strict: "throw" })
 export class EvolutionRequirements {
     @Prop()
     _id: false;
@@ -63,7 +63,7 @@ export const EvolutionRequirementsSchema = SchemaFactory.createForClass(Evolutio
 
 
 
-@Schema()
+@Schema({ strict: "throw" })
 export class AttackTypes {
     @Prop()
     _id: false;
@@ -89,7 +89,7 @@ export class AttackTypes {
 }
 export const AttackTypesSchema = SchemaFactory.createForClass(AttackTypes);
 
-@Schema()
+@Schema({ strict: "throw" })
 export class Attacks {
     @Prop()
     _id: false;

--- a/src/infrastructure/mongoDB/schemas/pokemon.schema.ts
+++ b/src/infrastructure/mongoDB/schemas/pokemon.schema.ts
@@ -2,7 +2,7 @@ import { Prop, Schema, SchemaFactory } from '@nestjs/mongoose';
 import mongoose, { Document } from 'mongoose';
 import { HeightWeightSchema, EvolutionSchema, EvolutionRequirementsSchema, AttacksSchema, Evolution, EvolutionRequirements, HeightWeight, AttackTypes, Attacks } from './nestSchemas.schema';
 
-@Schema()
+@Schema({ strict: "throw" })
 export class PokemonSchemaClass {
     @Prop({
         required: true,
@@ -31,7 +31,6 @@ export class PokemonSchemaClass {
         type: HeightWeightSchema,
     })
     weight: HeightWeight;
-
 
     @Prop({
         required: true,
@@ -75,6 +74,30 @@ export class PokemonSchemaClass {
 
     @Prop({ required: true, default: false, type: Boolean })
     favorite: boolean;
+
+    @Prop({ type: String })
+    "Pokémon Class": string
+
+    @Prop({ type: String })
+    "LEGENDARY": string
+
+    @Prop({ type: String })
+    "MYTHIC": string
+
+    @Prop({ type: String })
+    "Common Capture Area": string
+
+    @Prop({ type: String })
+    "Asia": string
+
+    @Prop({ type: String })
+    "North America": string
+
+    @Prop({ type: String })
+    "Western Europe": string
+
+    @Prop({ type: String })
+    "Australia, New Zealand": string
 }
 
 export type PokemonDocument = PokemonSchemaClass & Document;

--- a/src/presentation/pokemon.controller.ts
+++ b/src/presentation/pokemon.controller.ts
@@ -16,13 +16,19 @@ export class PokemonController {
      */
     @Get()
     async find(@Query() query) {
-        const skip = query.skip || "0"
-        const limit = query.limit || "10"
-        const pokemons = await this.PokemonService.find(query, skip, limit)
-        if (pokemons.length == 0) {
-            throw new NotFoundException("No Pokemon match the query: " + stringify(query))
+
+        let { skip, limit, ...filterQuery } = query
+        skip = skip || "0"
+        limit = limit || "10"
+        try {
+            const pokemons = await this.PokemonService.find(filterQuery, skip, limit)
+            if (pokemons.length == 0) {
+                throw new NotFoundException("No Pokemon match the query: " + stringify(query))
+            }
+            return { skip: skip, limit: limit, query: filterQuery, data: pokemons.map((p) => new PokemonSummaryDto(p)) }
+        } catch (error) {
+            throw new BadRequestException(`Path '${error.path}' does not exist in Pokemon`)
         }
-        return { skip: skip, limit: limit, data: pokemons.map((p) => new PokemonSummaryDto(p)) }
     }
 
     /**

--- a/test/infrastructure/pokemon.repository.spec.ts
+++ b/test/infrastructure/pokemon.repository.spec.ts
@@ -1,7 +1,7 @@
 import { TestingModule, Test } from "@nestjs/testing";
 import { PokemonRepository } from "../../src/infrastructure/mongoDB/pokemon.repository";
 import * as fs from 'fs';
-import mongoose, { Model } from "mongoose";
+import mongoose, { Model, MongooseError } from "mongoose";
 import { PokemonDocument, PokemonSchema } from "../../src/infrastructure/mongoDB/schemas/pokemon.schema";
 import { MongoMemoryServer } from "mongodb-memory-server";
 import { seed } from "../../src/infrastructure/scripts/seed-db";
@@ -128,10 +128,9 @@ describe("PokemonRepository", () => {
             // Update pokemon with id "001" with valid options {banana: true}
             const id = "001"
             const values = { "banana": true }
-            let result = await pokemonRepository.updateOne(id, values)
-            console.log(result);
 
-            expect(result).toBe(null)
+            await expect(pokemonRepository.updateOne(id, values)).rejects.toBeInstanceOf(Error);
+
         })
 
         it('should update a valid pokemon with valid values on a populated database', async () => {
@@ -152,9 +151,8 @@ describe("PokemonRepository", () => {
 
             const id = "001"
             const values = { "banana": true }
-            let result = await pokemonRepository.updateOne(id, values)
 
-            await expect(result['banana']).toBe(undefined)
+            await expect(pokemonRepository.updateOne(id, values)).rejects.toBeInstanceOf(Error);
 
         })
 
@@ -175,9 +173,8 @@ describe("PokemonRepository", () => {
 
             const id = "000"
             const values = { "banana": true }
-            let result = await pokemonRepository.updateOne(id, values)
 
-            await expect(result).toBe(null)
+            await expect(pokemonRepository.updateOne(id, values)).rejects.toBeInstanceOf(Error);
         })
     })
 


### PR DESCRIPTION
Update schemas to use strict mode throw. This does not allow for filtering by fields that do not exist. Had to update the schema and entity to include the one-off fields in some of the later pokemon. 